### PR TITLE
Adds a config for d3-based projects

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -1,6 +1,7 @@
 'use strict';
 var mainConfig = require('./es5');
 var idLengthOptions = mainConfig.rules['id-length'][1];
+var idMatchOptions = mainConfig.rules['id-match'][2];
 module.exports = {
   rules : {
     'id-length': [
@@ -17,8 +18,7 @@ module.exports = {
       // they may not include numbers, except as a part of the phrase "d3"
       '^([A-Za-z]*([dD]3)?[A-Za-z]*|([A-Z]|(D3))[A-Z_]*((D3)?[A-Z_]*[A-Z]|D3))$',
       {
-        // identifiers in properties are also checked
-        'properties': true,
+        'properties': idMatchOptions.properties,
       },
     ],
   },

--- a/d3.js
+++ b/d3.js
@@ -15,7 +15,7 @@ module.exports = {
       2,
       // identifiers must always be camel cased, unless they are all caps
       // they may not include numbers, except as a part of the phrase "d3"
-      '^([A-Za-z]*([dD]3)?[A-Za-z]*|[A-Z][A-Z_]*((D3)?[A-Z_]*[A-Z]|D3))$',
+      '^([A-Za-z]*([dD]3)?[A-Za-z]*|([A-Z]|(D3))[A-Z_]*((D3)?[A-Z_]*[A-Z]|D3))$',
       {
         // identifiers in properties are also checked
         'properties': true,

--- a/d3.js
+++ b/d3.js
@@ -8,7 +8,7 @@ module.exports = {
       {
         'min': idLengthOptions.min,
         'max': idLengthOptions.max,
-        'exceptions': idLengthOptions.exceptions.concat([ 'd', 'dx', 'dy', 'r', 'cx', 'cy', 'd3' ]),
+        'exceptions': idLengthOptions.exceptions.concat([ 'd', 'dx', 'dy', 'd3' ]),
       },
     ],
     'id-match': [

--- a/d3.js
+++ b/d3.js
@@ -1,0 +1,15 @@
+'use strict';
+var mainConfig = require('./es5');
+var idLengthOptions = mainConfig.rules['id-length'][1];
+module.exports = {
+  rules : {
+    'id-length' : [
+      2,
+      {
+        'min': idLengthOptions.min,
+        'max': idLengthOptions.max,
+        'exceptions': idLengthOptions.exceptions.concat([ 'd', 'dx', 'dy', 'r', 'cx', 'cy' ]),
+      },
+    ],
+  },
+};

--- a/d3.js
+++ b/d3.js
@@ -3,12 +3,22 @@ var mainConfig = require('./es5');
 var idLengthOptions = mainConfig.rules['id-length'][1];
 module.exports = {
   rules : {
-    'id-length' : [
+    'id-length': [
       2,
       {
         'min': idLengthOptions.min,
         'max': idLengthOptions.max,
-        'exceptions': idLengthOptions.exceptions.concat([ 'd', 'dx', 'dy', 'r', 'cx', 'cy' ]),
+        'exceptions': idLengthOptions.exceptions.concat([ 'd', 'dx', 'dy', 'r', 'cx', 'cy', 'd3' ]),
+      },
+    ],
+    'id-match': [
+      2,
+      // identifiers must always be camel cased, unless they are all caps
+      // they may not include numbers, except as a part of the phrase "d3"
+      '^([A-Za-z]*([dD]3)?[A-Za-z]*|[A-Z][A-Z_]*((D3)?[A-Z_]*[A-Z]|D3))$',
+      {
+        // identifiers in properties are also checked
+        'properties': true,
       },
     ],
   },


### PR DESCRIPTION
This patch mostly addresses variable naming: several short variable names that are regularly used in d3 are permitted: `d3`, `d`, `dx`, and `dy`.

It also permits "d3" in variable names, without allowing numbers to appear generally in them otherwise.
