### PR TITLE
fix: relax prefer-reflect entirely - deprecated

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -63,7 +63,7 @@ module.exports.rules['prefer-const'] = 2;
 // disallow parseInt() in favor of binary, octal, and hexadecimal literals
 module.exports.rules['prefer-numeric-literals'] = 2;
 // suggest using Reflect methods where applicable
-module.exports.rules['prefer-reflect'] = 2;
+module.exports.rules['prefer-reflect'] = 0;
 // suggest using the rest parameters instead of arguments
 module.exports.rules['prefer-rest-params'] = 2;
 // suggest using the spread operator instead of .apply()


### PR DESCRIPTION
http://eslint.org/docs/rules/prefer-reflect

> This rule was deprecated in ESLint v3.9.0 and will not be replaced.
> The original intent of this rule now seems misguided as we have come
> to > understand that `Reflect` methods are not actually intended to
> replace the `Object` counterparts the rule suggests, but rather exist
> as low-level > primitives to be used with proxies in order to
> replicate the default > behavior of various previously existing
> functionality.

Fixes #30.