### PR TITLE
feat: add rules from eslint 3.17.0

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -16,6 +16,8 @@ module.exports = {
     // # Possible Errors
     // The following rules point out areas where you might have made mistakes.
 
+    // disallow comparing against -0
+    'no-compare-neg-zero': 2,
     // disallow assignment in conditional expressions
     'no-cond-assign': 2,
     // disallow use of console
@@ -663,6 +665,8 @@ module.exports = {
     'no-unneeded-ternary': 2,
     // disallow whitespace before properties
     'no-whitespace-before-property': 2,
+    // enforce the location of single-line statements
+    'nonblock-statement-body-position': 0,
     // enforce consistent line breaks inside braces
     'object-curly-newline': 0,
     // require or disallow padding inside curly braces

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     }
   },
   "dependencies": {
-    "eslint": "^3.15.0",
+    "eslint": "^3.17.0",
     "eslint-plugin-filenames": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
BREAKING CHANGE:

Old code may cause errors with this new configuration

- [no-compare-neg-zero](http://eslint.org/docs/rules/no-compare-neg-zero) turned on.

- [nonblock-statement-body-position](http://eslint.org/docs/rules/nonblock-statement-body-position) turned off because:

   > You can also disable this rule if you’re using the `"all"` option for the `curly` rule, because this will disallow single-line statements entirely.